### PR TITLE
Feat: Make the chat realtime by Implementing SocketIO Event Listener from Client + Emit from server

### DIFF
--- a/hooks/use-chat-socket.ts
+++ b/hooks/use-chat-socket.ts
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Member, Message, Profile } from "@prisma/client";
+
+import { useSocket } from "@/components/providers/socket-provider";
+
+type ChatSocketProps = {
+  addKey: string;
+  updateKey: string;
+  queryKey: string;
+}
+
+type MessageWithMemberWithProfile = Message & {
+  member: Member & {
+    profile: Profile;
+  }
+}
+
+export const useChatSocket = ({
+  addKey,
+  updateKey,
+  queryKey
+}: ChatSocketProps) => {
+  const { socket } = useSocket();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!socket) {
+      return;
+    }
+    // TODO: Add update event
+    // TODO: Add delete event
+
+    socket.on(addKey, (message: MessageWithMemberWithProfile) => {
+      queryClient.setQueryData([queryKey], (oldData: any) => {
+        console.log('THISS ISS ADD EVENT', addKey)
+        if (!oldData || !oldData.pages || oldData.pages.length === 0) {
+          return {
+            pages: [{
+              items: [message],
+            }]
+          }
+        }
+
+        const newData = [...oldData.pages];
+
+        newData[0] = {
+          ...newData[0],
+          items: [
+            message,
+            ...newData[0].items,
+          ]
+        };
+
+        return {
+          ...oldData,
+          pages: newData,
+        };
+      });
+    });
+
+    return () => {
+      socket.off(addKey);
+    }
+  }, [queryClient, addKey, queryKey, socket, updateKey]);
+}

--- a/pages/api/socket/messages/index.ts
+++ b/pages/api/socket/messages/index.ts
@@ -84,6 +84,8 @@ export default async function handler(
       }
     });
 
+    const channelKey = `chat:${channelId}:messages`;
+    res?.socket?.server?.io?.emit(channelKey, message);
 
     return res.status(200).json(message);
   } catch (error) {


### PR DESCRIPTION
#  Implement SocketIO Event Listener from Client - Listen for the Message creation
(doc for socket io event listening: https://socket.io/docs/v4/listening-to-events/)
### Changes
1. Client side:
- create hook `useChatSocket`: add event listener to the client-io by the `unique key` that has been named to the react-query for getting messages list.

2. Server side:
- after successfully creating a message, the server-io will emit a message to the client with the `unique-key` that has been used for calling Create-Message route. 